### PR TITLE
feat: permit passing a prefix to clay.type

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -7,13 +7,14 @@ jsf.formats('semver', function(gen) {
 })
 jsf.extend('faker', function(faker) {
   faker.clay = {
-    type: function() {
+    type: function(prefix) {
+      prefix = prefix || ''
       var length = faker.helpers.randomize([1,1,1,2,2,3])
       var type = []
       for (var i = 0; i < length; i++) {
         type.push(faker.helpers.slugify(faker.hacker.noun()))
       }
-      return type.join('-')
+      return prefix + type.join('-')
     }
   }
 


### PR DESCRIPTION
Usage, e.g. for a User:

```json
"properties": {
  "_id": {
    "type": "string",
    "faker": {
      "clay.type": "user:"
    }
  }
}
```