### PR TITLE
feat: optional fake data for all properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ A typical error object looks like this:
 ```
 
 
-## Generate Fake Data: `clay.generate([attributes][, opts])`
+## Generate Fake Data: `clay.generate([attributes[, opts]])`
 Use this method if you want to get fake data. Utilizes
 [json-schema-faker](https://github.com/pateketrueke/json-schema-faker).
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ var person = new Clay({
       name: {
         type: 'string',
         minLength: 1
+      },
+      age: {
+        type: 'number'
       }
     },
     required: ['name']
@@ -31,7 +34,7 @@ var person = new Clay({
     type: 'person',
     version: '1.2.3'
   }
-}) 
+})
 
 person.validate({
   type: 'person',
@@ -99,12 +102,16 @@ A typical error object looks like this:
 ```
 
 
-## Generate Fake Data: `clay.generate([attributes])`
+## Generate Fake Data: `clay.generate([attributes][, opts])`
 Use this method if you want to get fake data. Utilizes
 [json-schema-faker](https://github.com/pateketrueke/json-schema-faker).
+
 If an `attributes` object is provided, its properties will be used instead of
 faked values.
 
+Passing `opts` modifies json-schema-faker behaviour:
+
+* `opts.all`: generate fake data for all of the schema's properties, not just required properties.
 
 ## `Clay.schema`
 Holds the `schema`.
@@ -130,6 +137,38 @@ var person = new Clay()
 cli(person, process.argv.slice(2))
 ```
 
+Shell usage:
+
+```js
+./cli.js
+{
+  "type": "person",
+  "version": "1.2.3"
+}
+```
+
+Arguments will be added as attributes:
+
+```shell
+./cli.js --name Matt
+{
+  "type": "person",
+  "version": "1.2.3",
+  "name": "Matt"
+}
+```
+
+Arguments after `--` will be passed as options to `generate`:
+
+```shell
+./cli.js --name Matt -- --all
+{
+  "type": "person",
+  "version": "1.2.3",
+  "name": "Matt",
+  "age": 27
+}
+```
 
 ## Browserify Build
 ```sh

--- a/cli.js
+++ b/cli.js
@@ -1,11 +1,16 @@
 var minimist = require('minimist')
 
 module.exports = function(model, argv) {
+  var opts = {}
   var attributes = minimist(argv)
+
+  if (attributes._.indexOf('--all') !== -1) {
+    opts.all = true
+  }
 
   delete attributes._
 
-  var model = model.generate(attributes)
+  var model = model.generate(attributes, opts)
 
   console.log(JSON.stringify(model, null, '  '))
 }

--- a/generate.js
+++ b/generate.js
@@ -20,11 +20,29 @@ jsf.extend('faker', function(faker) {
   return faker
 })
 
+function getAllProperties(schema) {
+  if (!schema.properties) {
+    return
+  }
+  var required = Object.keys(schema.properties || {})
+  if (!required.length) {
+    return
+  }
+  return {
+    required
+  }
+}
 
-module.exports = function(attributes) {
+module.exports = function(attributes, opts) {
   attributes = attributes || {}
+  var schema = this.schema
 
-  var data = jsf(this.schema, this.refs)
+  if (opts && opts.all) {
+    // Until https://github.com/json-schema-faker/json-schema-faker/issues/81
+    schema = Object.assign({}, schema, getAllProperties(schema))
+  }
+
+  var data = jsf(schema, this.refs)
 
   return merge(data, this.defaults, attributes)
 }


### PR DESCRIPTION
Appending `-- --all` to the CLI will generate fake data for all properties, not just required fields. Eventually, this should be handled by json-schema-faker itself, but in the meantime, it can be useful when writing schemas.